### PR TITLE
Update threshold_visualizer.gd

### DIFF
--- a/addons/gaea/editor/threshold_visualizer.gd
+++ b/addons/gaea/editor/threshold_visualizer.gd
@@ -1,40 +1,61 @@
 extends TextureRect
 
+# A custom control to preview noise areas (in white) versus non-affected areas (in black).
+# The colorization is based on the "min" and "max" thresholds from the assigned 'object'.
+# If the value is within the threshold range, it becomes white; otherwise black.
+# If no valid noise is found, the texture is cleared.
+
 var object: Object
 
-
 func _ready() -> void:
+	# Set a consistent size and aspect ratio handling for this preview.
 	custom_minimum_size = Vector2(128, 128)
 	stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
 	texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
 	focus_mode = Control.FOCUS_NONE
-	custom_minimum_size = get_combined_minimum_size()
-	tooltip_text = "White is where the generator/modifier will affect the tiles, black is where it won't."
 
+	# Adjust size after setting stretch_mode to ensure no dimension issues.
+	custom_minimum_size = get_combined_minimum_size()
+
+	# Provide a helpful tooltip for users.
+	tooltip_text = "White = tile is affected, Black = tile is unaffected."
 
 func update() -> void:
-	var noise: FastNoiseLite = null
-	if object is Modifier or object is NoiseCondition:
-		noise = object.get("noise") as FastNoiseLite
-	elif object is NoiseGeneratorData:
-		noise = object.settings.get("noise")
-
+	var noise: FastNoiseLite = _extract_noise_from_object()
 	if not is_instance_valid(noise):
 		texture = null
 		return
 
-	var image: Image = noise.get_seamless_image(128, 128)
-	for x in image.get_size().x:
-		for y in image.get_size().y:
-			var value: float = noise.get_noise_2d(x, y)
+	var size := 128
+	var image: Image = noise.get_seamless_image(size, size)
+
+	# Because 'image.get_size()' returns a Vector2i,
+	# we need range() to properly iterate in GDScript.
+	for x in range(size):
+		for y in range(size):
+			var value := noise.get_noise_2d(x, y)
 			if _is_in_threshold(value):
 				image.set_pixel(x, y, Color.WHITE)
 			else:
 				image.set_pixel(x, y, Color.BLACK)
+
 	texture = ImageTexture.create_from_image(image)
 
+func _extract_noise_from_object() -> FastNoiseLite:
+	# Depending on the 'object' type, extract the relevant noise reference.
+	if object is Modifier or object is NoiseCondition:
+		return object.get("noise")
+	elif object is NoiseGeneratorData:
+		return object.settings.get("noise")
+	return null
 
 func _is_in_threshold(value: float) -> bool:
-	if object.get("max") and object.get("min"):
-		return value >= object.get("min") and value <= object.get("max")
+	# If 'min' and 'max' exist, check that 'value' is within [min, max].
+	# Otherwise, default to false if thresholds are missing or invalid.
+	var has_min := object.has("min")
+	var has_max := object.has("max")
+	if has_min and has_max:
+		var min_val: float = object.get("min")
+		var max_val: float = object.get("max")
+		return value >= min_val and value <= max_val
 	return false


### PR DESCRIPTION
Explanation of Improvements
Dedicated _extract_noise_from_object()

Pulled out the logic for retrieving the FastNoiseLite instance to keep the main update() method more readable. Consistent Looping on Image Size

Switched to a typical for x in range(size): approach, ensuring we directly use the numeric size (which is set to 128 for both width and height). This avoids any ambiguity with image.get_size().x, which returns a Vector2 field in GDScript. Tooltip & Comments

Enhanced the tooltip text for clarity.
Provided more descriptive comments regarding how the logic works. Improved _is_in_threshold

Specifically checks if object has “min” and “max” properties, avoiding potential runtime errors or incomplete checks. Naming & Style

Used slightly more descriptive variable naming (size rather than a repeated literal). Ensured the style is consistent with typical GDScript conventions (e.g., snake_case for functions and variables).